### PR TITLE
Support more nonstandard whitespace

### DIFF
--- a/src/PriceParser.php
+++ b/src/PriceParser.php
@@ -330,7 +330,15 @@ class PriceParser
      */
     private function parseMatch(int $matchNumber, string $matchedText) : ?PriceMatch
     {
-        $matchedText = str_replace(' ', ' ', $matchedText);
+        $nonStandardWhitespace = [
+            ' ', // Non-breaking space
+            ' ', // Narrow no-break space
+            ' ', // Thin space
+            ' ', // Hair space
+            ' ', // Punctuation space
+        ];
+
+        $matchedText = str_replace($nonStandardWhitespace, ' ', $matchedText);
 
         $this->debug('Match [#%s] | Parsing match [%s]', $matchNumber, $matchedText);
 

--- a/tests/TestSuites/Parser/DetectPriceTests.php
+++ b/tests/TestSuites/Parser/DetectPriceTests.php
@@ -41,10 +41,11 @@ final class DetectPriceTests extends CurrencyParserTestCase
             42.12,
             15.00,
             500.00,
-            9.00
+            9.00,
+            18.25
         );
 
-        $this->assertCount(7, $result);
+        $this->assertCount(8, $result);
 
         foreach ($result as $idx => $match) {
             $this->assertSame(
@@ -344,6 +345,7 @@ EOT;
 15,-EUR
 EUR 500 TTC
 €9
+€ 18.25
 EOT;
 
     // endregion


### PR DESCRIPTION
Hi! Fantastic little project! Thanks for making this.

In a current project, we're formatting prices with thin spaces, which unfortunately the library doesn't recognize. This PR adds support for additional nonstandard whitespace characters: thin space, hair space, thin nonbreaking space and punctuation space.

Added tests that demonstrate the new behavior.